### PR TITLE
Generic values

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Precursor is a small, experimental programming language implemented as a pure
 TypeScript (or pure JavaScript) library.
 
 You can read more details below in the *overview*, and you can even
-[try it out in a live demonstration in your browser](https://niltag.net/code/precursor)
+[try it out in a live demonstration in your browser][precursordemo].
 
-Licensed under the `GPL-3`.
+[precursordemo]: https://niltag.net/code/precursor
+
+Licensed under the `GPL-3` where it can be, and the `WTFPL` elsewhere.
 
 # build and install from source
 
@@ -17,25 +19,37 @@ and, in fact, must - simply by running:
 npm i
 ```
 
-# Synopsis
+# synopsis
+
+## an attempt with words
 
 Precursor is a small programming language which you may grow and build upon (a
-"precursor," if you like).
+*precursor*, if you like).
 
 The default distribution consists of 3 components which work together "out of
-the box".
+the box":
 
-To be perfectly honest, I keep circling on how best to approach explaining what
-this is, if only because *I'm* deficient in my didactic abilities.
+- a small [**call-by-push-value**][cbpvarticle] language, `Cbpv`, defined as a
+  data type that you can manipulate in code (`grammar.ts`);
+- a [CESK][cekarticle]-based evaluator which operates on `Cbpv` objects
+  (`ceskm.ts`) ;
+- a parser for an [s-expression][sexprarticle] syntax, which parses source code
+  `string`s into `Cbpv` values(`parser.ts`).
 
-The following shows an example of how to construct an evaluator for the default
-surface language (if you're willing to write your own parser you can absolutely
-substitute in your own surface syntax!) and a simple set of possible result
-types.
+[cekarticle]: https://en.wikipedia.org/wiki/CEK_Machine
+[cbpvarticle]: https://en.wikipedia.org/wiki/Call-by-push-value
+[sexprarticle]: https://en.wikipedia.org/wiki/S-expression
 
-First, we sub-classed `CESKM` and specified that, in addition to the built-in
-value types of *closures* and *continuations*, we will be dealing in `number`s,
-`boolean`s, and `null`.
+You can see examples of the syntax parsed by the default parser in
+`__tests__/index.test.ts`.
+
+## example
+
+The following is an example usage of Precursor.
+We will use the parser that comes with the library, and create an evaluator
+that can compute with `number`, `boolean`, and `null` values.
+
+First, we sub-class `CESKM` and specify the values our machine can work with.
 
 ```typescript
 import {
@@ -52,9 +66,12 @@ class ExampleMachine<Val> extends CESKM<Val> {
   constructor (program: string) { super(parse_cbpv(program)); }
 ```
 
-Accordingly we must override `literal` and `primop`: the first to define how
-literal expressions are to be converted into `Value`s; and the second to define
-the primitive operations on data your machine is able to perform.
+Now we must override the methods `literal` and `primop`.
+
+`literal` defines how "literal" values are to be converted into `Value`s.
+A literal is something like a number (eg, `42`), `"doubly quoted string"`, or
+boolean `#t`rue `#f`alse symbols.
+You decide which of these to accept and how to evaluate them literally.
 
 ```typescript
   protected literal(v: any): Value<Val> {
@@ -64,6 +81,41 @@ the primitive operations on data your machine is able to perform.
       { return { v }; }
     throw new Error(`${v} not a primitive value`);
   }
+```
+
+`primop` defines the *primitive operations* ("primops") your machine can
+perform on `Value`s.
+The `CESKM` base class defines no primops: by default, the machine can only
+"do" what you permit it to do.
+
+*Aside*: The built-in parser, by convention, treats all symbols beginning with
+`prim:` as primitive operators, eg:
+
+```
+(prim:mul 1 2)
+
+    =>
+
+{
+  "tag": "cbpv_primop",
+  "op": "prim:mul",
+  "erands": [
+    {
+      "tag": "cbpv_literal",
+      "v": 1
+    },
+    {
+      "tag": "cbpv_literal",
+      "v": 2
+    }
+  ]
+}
+```
+
+There is no brilliant reason for this, it just keeps the interaction between
+the parser and the evaluator simple in lieu of a more principled mechanism.
+
+```typescript
   protected primop(op_sym: string, args: Value<Val>[]): Value<Val> {
     switch (op_sym) {
       case "prim:mul": {
@@ -84,7 +136,9 @@ the primitive operations on data your machine is able to perform.
 Primitive operators are not complete terms by themselves - they aren't
 variables you can pass around as an argument.
 Think of them as the "assembly" instructions of your evaluator.
-You will likely be defining functions which wrap them.
+You can write functions that call primops and pass *those* around all day.
+
+---
 
 Having supplied the universe of result types and filled in how they relate to
 literal expressions and what primitive operators are defined for them, you can
@@ -94,13 +148,24 @@ literal expressions and what primitive operators are defined for them, you can
 const example_machine = new ExampleMachine(`
 (letrec (
   (square (λ (n)
-    (let n (? n)      ; prim-op arguments must be *fully* evaluated
-    (prim:mul n n))))
-)
-((? square) 3)
+    (let n (? n)      ; prim-op arguments must be *fully* evaluated.
+    (prim:mul n n)))) ; higher level languages might not expose primops
+)                     ; directly.
+
+((? square) 3) ; a function defined in a `letrec` is automatically
+               ; "suspended" and must be "resumed" with `?` before
+               ; applying it to arguments (in this case, `3`).
 )
 `);
 
 assert.deepStrictEqual(example_machine.run(), { v: 9 });
 ```
 
+# questions / comments
+
+You can submit bugs through the Issues feature at
+https://github.com/gatlin/precursor-ts .
+
+As well you may email me at `gatlin+precursor@niltag.net`.
+I reserve the right to be terrible at replying; you should absolutely not take
+it personally.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,12 @@ npm i
 Precursor is a small programming language which you may grow and build upon (a
 "precursor," if you like).
 
+It's more of a meta-language, though: one you might use to define a more
+sophisticated one on top.
+Sort of like a precursor.
+
 The default distribution consists of 3 components which work together "out of
 the box".
-
----
 
 To be perfectly honest, I keep circling on how best to approach explaining what
 this is, if only because *I'm* deficient in my didactic abilities.

--- a/README.md
+++ b/README.md
@@ -22,10 +22,6 @@ npm i
 Precursor is a small programming language which you may grow and build upon (a
 "precursor," if you like).
 
-It's more of a meta-language, though: one you might use to define a more
-sophisticated one on top.
-Sort of like a precursor.
-
 The default distribution consists of 3 components which work together "out of
 the box".
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,53 @@ const example_machine = new ExampleMachine(`
 assert.deepStrictEqual(example_machine.run(), { v: 9 });
 ```
 
+## are there data structures? a type system?
+
+Ultimately I would like to include a type checker for `Cbpv` which supports
+*linear call-by-push-value with graded coeffects.*
+I'll let you look up the parts of that which interest you.
+
+As for data structures,
+
+1. Nothing yet,
+2. look at this:
+
+```typescript
+const example_machine = new ExampleMachine(`
+(letrec (
+  (cons (λ (a b) (reset ((shift k k) a b))))
+)
+(let p1 ((? cons) 3 #f)
+p1)
+)
+`);
+console.log(example_machine.run());
+```
+
+This prints the following:
+
+```json
+{
+  "_kont": {
+    "_args": [
+      {
+        "v": 3
+      },
+      {
+        "v": false
+      }
+    ],
+    "_kont": {}
+  }
+}
+```
+
+This captured a set of arguments being passed to a "function" `(shift k k)` and
+converted them into what looks suspiciously like a composite or product value
+of some kind.
+
+Stay tuned!
+
 # questions / comments
 
 You can submit bugs through the Issues feature at

--- a/README.md
+++ b/README.md
@@ -17,14 +17,7 @@ and, in fact, must - simply by running:
 npm i
 ```
 
-# overview
-
-What follows is my best attempt at a summary for anyone who wanders into this
-repository and wants to know how to find out more.
-I think the best way to get a feel for its usage is to take a look at the unit
-tests in the `__tests__` directory.
-
----
+# Synopsis
 
 Precursor is a small programming language which you may grow and build upon (a
 "precursor," if you like).
@@ -32,186 +25,84 @@ Precursor is a small programming language which you may grow and build upon (a
 The default distribution consists of 3 components which work together "out of
 the box".
 
-## *CESKM* Evaluator
+---
 
-`ceskm.ts` defines a CESKM [machine][cekarticle] to evaluate Precursor.
-It is called a *CESKM* machine because it consists of five components:
+To be perfectly honest, I keep circling on how best to approach explaining what
+this is, if only because *I'm* deficient in my didactic abilities.
 
-- **c**ontrol-string, the program expression being evaluated;
-- **e**nvironment, a mapping from variable names to *addresses* or
-  *definitions*;
-- **s**tore, a subsequent mapping from *addresses* to ***values***;
-- **k**ontinuation, the current [continuation][contarticle]; and
-- **m**eta stack, a control stack used in tandem with the continuation.
+The following shows an example of how to construct an evaluator for the default
+surface language (if you're willing to write your own parser you can absolutely
+substitute in your own surface syntax!) and a simple set of possible result
+types.
 
-[cekarticle]: https://en.wikipedia.org/wiki/CEK_Machine
-[contarticle]: https://en.wikipedia.org/wiki/Continuation
-
-The language grammar (below) can ultimately be thought of as the operating
-instructions for this machine.
-
-The objective of a CESKM machine is to evaluate the **c**ontrol string down to
-a value.
-Precursor (currently) defines the following language of values, meant to
-resemble JSON primitives (modified slightly for presentation):
+First, we sub-classed `CESKM` and specified that, in addition to the built-in
+value types of *closures* and *continuations*, we will be dealing in `number`s,
+`boolean`s, and `null`.
 
 ```typescript
-type Value
-  = { tag: 'closure', exp: Cbpv, env: Env }
-  | { tag: 'continuation', kont: Kont }
-  | { tag: 'number', v: number }
-  | { tag: 'boolean', v: boolean }
-  | { tag: 'string' , v: string }
-  | { tag: 'record' , v: Record<string, Value> }
-  | { tag: 'array' , v: Value[] };
+import {
+  CESKM,
+  Value,
+  parse_cbpv // use the pre-fab s-expression parser
+} from "precursor-ts";
+
+import { strict as assert } from "assert";
+
+type Val = number | boolean | null ;
+
+class ExampleMachine<Val> extends CESKM<Val> {
+  constructor (program: string) { super(parse_cbpv(program)); }
 ```
 
-In addition to numbers, booleans, strings, records, and arrays, we have
-
-- *closures*: ongoing computations with a closed environment which have more
-  work to be done before they can produce a result `Value`, created with the
-  `!` operator (see `Grammar`); and
-- *continuations*: continuations can be bound to variables using `shift`, and
-  this is what is inside that variable. If you don't know what a continuation
-  is, I refer you to the [article on the subject above][contarticle].
-
-### Step by step
-
-The base class implements a protected method `step` which "purely" acts on a
-*state* value consisting of the five components listed above.
-The output of each `step` is used as the input to the next `step`; evaluation
-terminates when `step` returns a `Value` type instead.
-
-The public method `run` implements this algorithm, but you are free to override
-it or supplement it with your own (for instance, you might want a "debug mode"
-where the machine yields each state to a logging system for review).
-
-## Grammar
-
-`grammar.ts` defines the Precursor grammar, `Cbpv`, as a plain-old-JSON type.
-Here is that definition, modified slightly for presentation.
+Accordingly we must override `literal` and `primop`: the first to define how
+literal expressions are to be converted into `Value`s; and the second to define
+the primitive operations on data your machine is able to perform.
 
 ```typescript
-type Cbpv
-  /* Positive */
-  = { tag: 'cbpv_number' ; v: number }    // eg, 5
-  | { tag: 'cbpv_boolean' ; v: boolean }  // #t, #f
-  | { tag: 'cbpv_string' ; v: string }    // "double-quotes only"
-  | { tag: 'cbpv_symbol' ; v: string }    // immutable
-  | { tag: 'cbpv_primop' ; op: string; erands: Cbpv[] } // see below
-  | { tag: 'cbpv_suspend'; exp: Cbpv }
-  /* Negative */
-  | { tag: 'cbpv_apply'; op: Cbpv; erands: Cbpv[] } // eg, (op arg1 arg2)
-  | { tag: 'cbpv_abstract'; args: string[]; body: Cbpv } // eg, (λ (x) (...))
-  | { tag: 'cbpv_let'; v: string; exp: Cbpv; body: Cbpv } // (let x 5 (...))
-  | { tag: 'cbpv_letrec'; bindings: [string,Cbpv][]; body: Cbpv } // see below
-  | { tag: 'cbpv_if'; c: Cbpv; t: Cbpv; e : Cbpv } //the author is iffy on this one
-  | { tag: 'cbpv_resume'; v: Cbpv } // weird
-  | { tag: 'cbpv_reset'; exp: Cbpv } // weird
-  | { tag: 'cbpv_shift'; karg: string; body: Cbpv } // weird
-  ;
+  protected literal(v: any): Value<Val> {
+    if ("number" === typeof v
+     || "boolean" === typeof v
+     || null === v)
+      { return { v }; }
+    throw new Error(`${v} not a primitive value`);
+  }
+  protected primop(op_sym: string, args: Value<Val>[]): Value<Val> {
+    switch (op_sym) {
+      case "prim:mul": {
+        if (! ("v" in args[0]) || ! ("v" in args[1]))
+          { throw new Error(`arguments must be values`); }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v)
+          { throw new Error(`arguments must be numbers`); }
+        let result: unknown = args[0].v * args[1].v;
+        return { v: result as Val };
+      }
+      // ... other prim ops
+      default: return super.primop(op_sym, args);
+    }
+  }
+}
 ```
 
-`Cbpv` stands for [*call-by-push-value*][cbpvarticle], a language foundation
-which is neither lazy **nor** strict.
-Instead, term evaluation is handled explicitly by two operators: `!`
-("suspend") and `?` ("resume").
+Primitive operators are not complete terms by themselves - they aren't
+variables you can pass around as an argument.
+Think of them as the "assembly" instructions of your evaluator.
+You will likely be defining functions which wrap them.
 
-[cbpvarticle]: https://en.wikipedia.org/wiki/Call-by-push-value
+Having supplied the universe of result types and filled in how they relate to
+literal expressions and what primitive operators are defined for them, you can
+`run` your machine down to a `Value<Result>`.
 
-### A polarizing subject
-
-In call-by-push-value terms are sorted into two (for lack of a better word, oy)
-kinds:
-
-*Positive* terms are data: terms which require no further evaluation or work by
-the machine in order to render as result values.
-Literals (numbers, strings, booleans, etc), variables, and *primops* are all
-positive.
-
-*Primitive operators* ("primops") are basic operations that the Precursor
-machine can perform on data.
-You might think of them as the basic instruction set for a CPU.
-By default the `CESKM` class defines a handful of primops to manipulate the
-basic data types but it is easy (and expected and encouraged) for you to add
-your own; see the unit tests for a concrete example!
-
-*Negative* terms are those which express some **irreversible** work to be done.
-For example, function abstraction (`cbpv_abstract` above) pops the top frame
-from the argument stack; function application pushes a frame on it and
-evaluates its (negative) operator; an `if` expression essentially chooses
-between two continuations and throws one away; etc.
-
-`!` *suspends* a negative ("active," "ongoing") computation into a closure
-value; `?` *resumes* suspended computations in order to evaluate them.
-
-### To be continued
-
-`shift` and `reset` are [delimited continuation][delimccarticle] operators.
-A *continuation* is an abstract representation of the control state of the
-program (according to Wikipedia).
-It represents a point in the computation with a specified amount of remaining
-work.
-
-[delimccarticle]: https://en.wikipedia.org/wiki/Delimited_continuation
-
-When handled with care, these four operators are very powerful:
-
-```
+```typescript
+const example_machine = new ExampleMachine(`
 (letrec (
-  (load (λ () (shift k
-    (! (λ (f) ((? (prim:record-get "load" f)) k))))))
-
-  (save (λ (v) (shift k
-    (! (λ (f) ((? (prim:record-get "save" f)) v k))))))
-
-  (return (λ (x) (shift k
-    (! (λ (_) (? x))))))
-
-  (run-state (λ (st comp)
-    (let handle (reset (? comp))
-    ((? handle) (prim:record-new
-      "load" (! (λ (continue)
-               (let res (! (continue st))
-               ((? run-state) st res))))
-      "save" (! (λ (v continue)
-               (let res (! (continue _))
-               ((? run-state) v res)))))))))
-
-  (increment-state (λ ()
-    (let n ((? load))
-    (let _ ((? save) (prim:add n 1))
-    (let n-plus-1 ((? load))
-    ((? return) n-plus-1))))))
+  (square (λ (n)
+    (let n (? n)      ; prim-op arguments must be *fully* evaluated
+    (prim:mul n n))))
 )
-((? run-state) 255 (! ((? increment-state))))
+((? square) 3)
 )
-; result: 256
+`);
+
+assert.deepStrictEqual(example_machine.run(), { v: 9 });
 ```
-
-`!`, `?`, `shift`, and `reset` are here used to implement a small [effect
-system][effectsysarticle], in this case modeling a mutable state effect.
-
-[effectsysarticle]: https://en.wikipedia.org/wiki/Effect_system
-
-There's a lot more to say but not a lot of time!
-Hopefully though if you are the sort of person whom this could potentially
-excite, you'll be excited by now.
-
-## Parser
-
-Precursor comes with a parser for a small *s-expression* (think lisp) surface
-language which builds the `Cbpv` expressions evaluated by `CESKM`.
-The `parse_cbpv` function in `parser.ts` can be used without any fuss for
-exactly this.
-
-This language is meant to closely mirror the structure of the grammar itself;
-it's not supposed to win any awards for usability or ergonomics.
-This is why it exists in a separate module and why `CESKM` consumes a custom
-data type and not source code directly.
-
-# Questions / Comments / Issues
-
-Feel free to email the author at `gatlin+precursor@niltag.net`.
-You may also use the "Issues" feature on GitHub to report any feedback.
 

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,22 +1,146 @@
 import {
   CESKM,
   Value,
-  Kont,
-  Parser,
-  build_cbpv,
-  numval,
-  arrval,
   parse_cbpv
 } from "../src/index";
 
-class DebugMachine extends CESKM {
+type Val = number | boolean | null ;
+
+class DebugMachine<Val> extends CESKM<Val> {
   constructor (program: string) { super(parse_cbpv(program)); }
-  protected primop(op_sym: string, args: Value[]): Value {
+  protected literal(v: any): Value<Val> {
+    if ("number" === typeof v
+     || "boolean" === typeof v
+     || null === v)
+      { return { v }; }
+    throw new Error(`${v} not a primitive value`);
+  }
+  protected primop(op_sym: string, args: Value<Val>[]): Value<Val> {
     switch (op_sym) {
-      case "prim:mod": {
-        if ("number" === args[0].tag && "number" === args[1].tag) {
-          return numval(args[0].v % args[1].v);
+      case "prim:mul": {
+        if (! ("v" in args[0]) || ! ("v" in args[1]))
+          { throw new Error(`arguments must be values`); }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v)
+          { throw new Error(`arguments must be numbers`); }
+        let result: unknown = args[0].v * args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:add": {
+        if (! ("v" in args[0]) || ! ("v" in args[1]))
+          { throw new Error(`arguments must be values`); }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v)
+          { throw new Error(`arguments must be numbers`); }
+        let result: unknown = args[0].v + args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:sub": {
+        if (! ("v" in args[0]) || ! ("v" in args[1]))
+          { throw new Error(`arguments must be values`); }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v)
+          { throw new Error(`arguments must be numbers`); }
+        let result: unknown = args[0].v - args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:div": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
         }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v) {
+          throw new Error(`arguments must be numbers`);
+        }
+        let result: unknown = args[0].v / args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:mod": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v) {
+          throw new Error(`arguments must be numbers`);
+        }
+        let result: unknown = args[0].v % args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:eq": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if (("number" !== typeof args[0].v || "number" !== typeof args[1].v)
+         && ("boolean" !== typeof args[0].v || "boolean" !== typeof args[1].v) ) {
+          throw new Error(`arguments must be numbers or booleans`);
+        }
+        let result: unknown = args[0].v === args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:lt": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v) {
+          throw new Error(`arguments must be numbers`);
+        }
+        let result: unknown = args[0].v < args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:lte": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v) {
+          throw new Error(`arguments must be numbers`);
+        }
+        let result: unknown = args[0].v <= args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:gt": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v) {
+          throw new Error(`arguments must be numbers`);
+        }
+        let result: unknown = args[0].v > args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:gte": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if ("number" !== typeof args[0].v || "number" !== typeof args[1].v) {
+          throw new Error(`arguments must be numbers`);
+        }
+        let result: unknown = args[0].v >= args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:and": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if ("boolean" !== typeof args[0].v || "boolean" !== typeof args[1].v) {
+          throw new Error(`arguments must be booleans`);
+        }
+        let result: unknown = args[0].v && args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:or": {
+        if (! ("v" in args[0]) || ! ("v" in args[1])) {
+          throw new Error(`arguments must be values`);
+        }
+        if ("boolean" !== typeof args[0].v || "boolean" !== typeof args[1].v) {
+          throw new Error(`arguments must be booleans`);
+        }
+        let result: unknown = args[0].v || args[1].v;
+        return { v: result as Val };
+      }
+      case "prim:not": {
+        if (! ("v" in args[0]) ) {
+          throw new Error(`argument must be a value`);
+        }
+        if ("boolean" !== typeof args[0].v) {
+          throw new Error(`argument must be a boolean`);
+        }
+        let result: unknown = !args[0].v;
+        return { v: result as Val };
       }
       default: return super.primop(op_sym, args);
     }
@@ -32,7 +156,6 @@ describe("index", () => {
 ((? sqr-int) 69))`).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 4761
     });
   });
@@ -40,7 +163,6 @@ describe("index", () => {
     expect(new DebugMachine("( (\\ (x) (prim:mul x 2)) 210)").
       run()).
       toStrictEqual({
-        tag: 'number',
         v: 420
       });
   });
@@ -49,7 +171,6 @@ describe("index", () => {
     expect(new DebugMachine("(let n (prim:add 1 2) (prim:mul n 2))").
       run()).
       toStrictEqual({
-        tag: 'number',
         v: 6
       });
   });
@@ -67,7 +188,6 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 1814400
       });
   });
@@ -81,7 +201,6 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 8
       });
   });
@@ -94,7 +213,6 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 195
       });
   });
@@ -121,7 +239,6 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 355687428096000
       });
   });
@@ -148,7 +265,6 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 911666
       });
   });
@@ -176,7 +292,6 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: 'number',
         v: 6
       });
   });
@@ -223,7 +338,6 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 911672
       });
   });
@@ -250,7 +364,6 @@ describe("index", () => {
     let res = machine.run();
     expect(res).
       toStrictEqual({
-        tag: "boolean",
         v: false
     });
   }
@@ -290,7 +403,6 @@ describe("index", () => {
       `).
         run()).
         toStrictEqual({
-          tag: "number",
           v: 7
         });
   });
@@ -327,7 +439,6 @@ describe("index", () => {
       `).
         run()).
         toStrictEqual({
-          tag: "number",
           v: 17
         });
   });
@@ -346,52 +457,8 @@ describe("index", () => {
     `).
       run()).
       toStrictEqual({
-        tag: "number",
         v: 1814400
       });
-  });
-
-  test("string functions: length", () => {
-    expect(new DebugMachine(`
-    (prim:string-length "bottom text")
-    `).
-      run()).
-      toStrictEqual({
-        tag: "number",
-        v: 11
-      });
-  });
-
-  test('record delete', () => {
-    expect(new DebugMachine(`
-(let o1 (prim:record-new "key1" #f "key2" #t)
-(prim:record-del "key1" o1))
-`).
-           run()).
-      toStrictEqual({
-        tag: "record",
-        v: {
-          'key2': {
-            tag: "boolean",
-            v: true
-          }
-        }
-      });
-  });
-
-
-  test('array test', () => {
-    expect(new DebugMachine(`
-(let a1 (prim:array-new 1 2 3)
-(let a2 (prim:array-new)
-(let a3 (prim:array-concat a2 a1)
-(prim:array-length a3))))
-`).
-      run()).
-      toStrictEqual({
-        tag: "number",
-        v: 3
-    });
   });
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,15 @@
 {
   "name": "precursor-ts",
-  "version": "1.0.3",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.3",
+      "version": "0.1.6",
       "license": "GPL-3",
+      "dependencies": {
+        "bson": "^4.2.3"
+      },
       "devDependencies": {
         "@types/jest": "^26.0.20",
         "@types/node": "^14.14.13",
@@ -1238,6 +1241,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1294,6 +1316,40 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/bson": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
+      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2566,6 +2622,25 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/import-local": {
       "version": "3.0.2",
@@ -7270,6 +7345,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -7320,6 +7400,23 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "bson": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
+      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -8318,6 +8415,11 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "import-local": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "build": "tsc",
     "test": "jest",
     "coverage": "jest --coverage",
-    "prepare": "npm run test && npm run build",
-    "start": "ts-node ./src/index.ts"
+    "prepare": "npm run test && npm run build"
   },
   "jest": {
     "preset": "ts-jest",
@@ -28,8 +27,5 @@
     "ts-jest": "^26.5.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
-  },
-  "dependencies": {
-    "bson": "^4.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precursor-ts",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "A call-by-push-value virtual machine and language in pure typescript",
   "author": "Gatlin Johnson <gatlin@niltag.net>",
   "main": "./dist/index.js",
@@ -28,5 +28,8 @@
     "ts-jest": "^26.5.1",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "bson": "^4.2.3"
   }
 }

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -4,9 +4,7 @@
 
 // Call-By-Push-Value intermediate language.
 export type Cbpv
-  = { tag: "cbpv_number" ; v: number }
-  | { tag: "cbpv_boolean" ; v: boolean }
-  | { tag: "cbpv_string" ; v: string }
+  = { tag: "cbpv_literal" ; v: any }
   | { tag: "cbpv_symbol" ; v: string }
   | { tag: "cbpv_primop" ; op: string; erands: Cbpv[] }
   | { tag: "cbpv_suspend"; exp: Cbpv }
@@ -21,9 +19,7 @@ export type Cbpv
   ;
 
 // smart constructors
-export const cbpv_num = (v: number): Cbpv => ({ tag: "cbpv_number", v });
-export const cbpv_bool = (v: boolean): Cbpv => ({ tag: "cbpv_boolean", v });
-export const cbpv_str = (v: string): Cbpv => ({ tag: "cbpv_string", v });
+export const cbpv_lit = (v: any): Cbpv => ({ tag: "cbpv_literal", v });
 export const cbpv_sym = (v: string): Cbpv => ({ tag: "cbpv_symbol", v });
 export const cbpv_prim = (op: string, erands: Cbpv[]): Cbpv => ({
   tag: "cbpv_primop",
@@ -51,8 +47,7 @@ export const cbpv_if = (c: Cbpv, t: Cbpv, e: Cbpv): Cbpv => ({
   c, t, e });
 
 export const cbpv_is_positive = (expr: Cbpv): boolean => { switch (expr.tag) {
-    case "cbpv_number":
-    case "cbpv_boolean":
+    case "cbpv_literal":
     case "cbpv_symbol":
     case "cbpv_primop":
     case "cbpv_suspend":

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,10 +5,8 @@
 import {
   Cbpv,
   cbpv_is_positive,
-  cbpv_num,
-  cbpv_bool,
+  cbpv_lit,
   cbpv_sym,
-  cbpv_str,
   cbpv_prim,
   cbpv_app,
   cbpv_let,
@@ -212,11 +210,11 @@ export const build_cbpv = (ast: any): Cbpv => {
   }
   else {
     switch (typeof ast) {
-      case 'number': return cbpv_num(<number>ast);
-      case 'boolean': return cbpv_bool(<boolean>ast);
+      case 'number': return cbpv_lit(<number>ast);
+      case 'boolean': return cbpv_lit(<boolean>ast);
       case 'string': {
         if ('"' === ast.charAt(0)) {
-          return cbpv_str(<string>ast.substr(1,ast.length-2)); }
+          return cbpv_lit(<string>ast.substr(1,ast.length-2)); }
         return cbpv_sym(<string>ast);
       }
     }


### PR DESCRIPTION
This redefines `Value`:

```typescript
type Value<T>
  = { _exp: Cbpv, _env: Env }
  | { _kont: Kont<T> }
  | { v: T } ;
```

Accordingly `Kont` and `CESKM` were given parameters as well. The definition of the evaluator is now completely agnostic to runtime value representation and primitive operators.

Qualitatively, this *feels* right.