### PR TITLE
allow argk to destructure into letk variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precursor-ts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A call-by-push-value virtual machine and language in pure typescript",
   "author": "Gatlin Johnson <gatlin@niltag.net>",
   "main": "./dist/cjs/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "precursor-ts",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A call-by-push-value virtual machine and language in pure typescript",
   "author": "Gatlin Johnson <gatlin@niltag.net>",
   "main": "./dist/cjs/index.js",

--- a/src/ceskm.ts
+++ b/src/ceskm.ts
@@ -478,7 +478,7 @@ class CESKM<Base = null | boolean> {
         case "cbpv_let": {
           const { v, exp, body } = control;
           control = exp;
-          kontinuation = new Let([v], body, environment, kontinuation);
+          kontinuation = new Let(v, body, environment, kontinuation);
           break;
         }
         case "cbpv_letrec": {

--- a/src/ceskm.ts
+++ b/src/ceskm.ts
@@ -678,35 +678,24 @@ class CESKM<Base = null | boolean> {
             store = store.bind(addr, _args[i]);
             _env = _env.merge(frame);
           }
-          final = {
-            done: false,
-            value: {
-              control: _exp,
-              environment: _env,
-              store,
-              kontinuation: _k,
-              meta
-            }
-          };
-          finished = true;
         }
         else {
           const addr: string = this.gensym();
           frame = frame.bind(_let[0], addr);
           store = store.bind(addr, val);
           _env = _env.merge(frame);
-          final = {
-            done: false,
-            value: {
-              control: _exp,
-              environment: _env,
-              store,
-              kontinuation: _k,
-              meta
-            }
-          };
-          finished = true;
         }
+        final = {
+          done: false,
+          value: {
+            control: _exp,
+            environment: _env,
+            store,
+            kontinuation: _k,
+            meta
+          }
+        };
+        finished = true;
       }
       else {
         if (0 === meta.length) {

--- a/src/ceskm.ts
+++ b/src/ceskm.ts
@@ -670,23 +670,43 @@ class CESKM<Base = null | boolean> {
         const { _let, _exp, _k } = kontinuation;
         let { _env } = kontinuation;
         let frame: Env = this.empty_env();
-        for (let i = 0; i < _let.length; i++) {
-          const addr: string = this.gensym();
-          frame = frame.bind(_let[i], addr);
-          store = store.bind(addr, val);
-        }
-        _env = _env.merge(frame);
-        final = {
-          done: false,
-          value: {
-            control: _exp,
-            environment: _env,
-            store,
-            kontinuation: _k,
-            meta
+        if ("k" in val && ("_args" in val.k)) { // it's not an argk
+          const { _args } = val.k;
+          for (let i = 0; i < _let.length; i++) {
+            const addr: string = this.gensym();
+            frame = frame.bind(_let[i], addr);
+            store = store.bind(addr, _args[i]);
+            _env = _env.merge(frame);
           }
-        };
-        finished = true;
+          final = {
+            done: false,
+            value: {
+              control: _exp,
+              environment: _env,
+              store,
+              kontinuation: _k,
+              meta
+            }
+          };
+          finished = true;
+        }
+        else {
+          const addr: string = this.gensym();
+          frame = frame.bind(_let[0], addr);
+          store = store.bind(addr, val);
+          _env = _env.merge(frame);
+          final = {
+            done: false,
+            value: {
+              control: _exp,
+              environment: _env,
+              store,
+              kontinuation: _k,
+              meta
+            }
+          };
+          finished = true;
+        }
       }
       else {
         if (0 === meta.length) {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -23,7 +23,7 @@ type Cbpv =
   | { tag: "cbpv_resume"; v: Cbpv }
   | { tag: "cbpv_abstract"; args: string[]; body: Cbpv }
   | { tag: "cbpv_apply"; op: Cbpv; erands: Cbpv[] }
-  | { tag: "cbpv_let"; v: string; exp: Cbpv; body: Cbpv }
+  | { tag: "cbpv_let"; v: string[]; exp: Cbpv; body: Cbpv }
   | { tag: "cbpv_letrec"; bindings: [string, Cbpv][]; body: Cbpv }
   | { tag: "cbpv_reset"; exp: Cbpv }
   | { tag: "cbpv_shift"; karg: string; body: Cbpv }
@@ -80,7 +80,7 @@ const cbpv_app = (op: Cbpv, erands: Cbpv[]): Cbpv => ({
  * @category Language & Syntax
  * @public
  */
-const cbpv_let = (v: string, exp: Cbpv, body: Cbpv): Cbpv => ({
+const cbpv_let = (v: string[], exp: Cbpv, body: Cbpv): Cbpv => ({
   tag: "cbpv_let",
   v,
   exp,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -172,14 +172,23 @@ const build_cbpv = (ast: any): Cbpv => {
         return cbpv_lam(ast[1], build_cbpv(ast[2]));
       }
       case 'let': {
-        if ('string' !== typeof ast[1]) {
-          throw new Error('lhs of let-binding must be symbol');
+        if ('string' === typeof ast[1]) {
+          return cbpv_let(
+            [ast[1]],
+            build_cbpv(ast[2]),
+            build_cbpv(ast[3])
+          );
         }
-        return cbpv_let(
-          <string>ast[1],
-          build_cbpv(ast[2]),
-          build_cbpv(ast[3])
-        );
+        else if (Array.isArray(ast[1])) {
+          return cbpv_let(
+            ast[1] as string[],
+            build_cbpv(ast[2]),
+            build_cbpv(ast[3])
+          );
+        }
+        else {
+          throw new Error(`let must bind to single argument or list of variables`);
+        }
       }
       case 'letrec': {
         if (!Array.isArray(ast[1])) {


### PR DESCRIPTION
new behavior: if a letk is matched with an argk wrapped as a value, destructure the argk into the letk free variables.

Closes #36 .